### PR TITLE
Prevent failure of golangci-lint

### DIFF
--- a/tds/field.go
+++ b/tds/field.go
@@ -188,7 +188,9 @@ type fieldFmtBase struct {
 	// specific to TDS_ROWFMT2
 	// wide_row controls if the TDS_ROWFMT2 specific members are filled
 	// and written. It is set by TDS_ROWFMT2 when creating a field.
-	wide_row    bool
+
+	// Marked as comment to prevent failure of golangci-lint
+	// wide_row    bool
 	columnLabel string
 	catalogue   string
 	schema      string


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

To prevent the failure of golangci-lint one variable in tds/field.go was
marked as comment. Since this variable could be used in a future process it was
not deleted.

**Tests**

- [x] make lint
- [x] make test
