### PR TITLE
Post-migration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import (
 )
 
 func main() {
-    d := dsn.NewDsnInfo()
+    d := dsn.NewInfo()
     d.Host = "hostname"
     d.Port = "4901"
     d.Username = "user"

--- a/tds/login.go
+++ b/tds/login.go
@@ -93,7 +93,7 @@ func (tdsChan *Channel) Login(ctx context.Context, config *LoginConfig) error {
 	}
 
 	if loginack.Status != TDS_LOG_NEGOTIATE {
-		return fmt.Errorf("expected loginack with negotation, received: %s", loginack)
+		return fmt.Errorf("expected loginack with negotiation, received: %s", loginack)
 	}
 
 	pkg, err = tdsChan.NextPackage(ctx, true)

--- a/tds/loginConfig.go
+++ b/tds/loginConfig.go
@@ -34,7 +34,7 @@ type LoginConfig struct {
 
 	RemoteServers []LoginConfigRemoteServer
 
-	// Encrypt allows any TDSMsgId but only negotation-relevant security
+	// Encrypt allows any TDSMsgId but only negotiation-relevant security
 	// bits such as TDS_MSG_SEC_ENCRYPT will be recognized.
 	Encrypt TDSMsgId
 }

--- a/tds/packageEnvChange.go
+++ b/tds/packageEnvChange.go
@@ -12,7 +12,7 @@ import "fmt"
 // variable change types.
 type EnvChangeType uint8
 
-// Types of a changeable enviroment variable.
+// Types of a changeable environment variable.
 const (
 	TDS_ENV_DB       EnvChangeType = 0x1
 	TDS_ENV_LANG     EnvChangeType = 0x2

--- a/tds/packageParams.go
+++ b/tds/packageParams.go
@@ -105,7 +105,7 @@ func (pkg ParamsPackage) WriteTo(ch BytesChannel) error {
 	}
 
 	if err := ch.WriteByte(byte(token)); err != nil {
-		return fmt.Errorf("error ocurred writing TDS token %s: %w", token, err)
+		return fmt.Errorf("error occurred writing TDS token %s: %w", token, err)
 	}
 
 	for i, field := range pkg.DataFields {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fix deprecated function-name in README.md
Fix typos in several files (according to https://goreportcard.com/report/github.com/SAP/go-dblib#misspell)

**Tests**

- [x] make lint
- [x] make test
