### PR TITLE
Add missing space for reuse tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2020 SAP SE
 //
 // SPDX-License-Identifier: Apache-2.0
+
 module github.com/SAP/go-dblib
 
 go 1.15


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

reuse now correctly recognizes `go.mod` files, but needs an empty line between the license header and the code.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
