### PR TITLE
Update references to old repo layout

### DIFF
--- a/capability/doc.go
+++ b/capability/doc.go
@@ -17,7 +17,7 @@ In git.domain.tld/libA/libACaps:
 
 	package libACaps
 
-	import "github.com/SAP/go-ase/libase/capability"
+	import "github.com/SAP/go-dblib/capability"
 
 	var (
 		// Bug appeared in version 0.9.0, no published version has a fix

--- a/tds/loginConfig.go
+++ b/tds/loginConfig.go
@@ -68,7 +68,7 @@ func NewLoginConfig(dsn *dsn.Info) (*LoginConfig, error) {
 	}
 
 	// Should be overwritten by clients
-	conf.AppName = "github.com/SAP/go-ase/libase/tds"
+	conf.AppName = "github.com/SAP/go-dblib/tds"
 
 	conf.CharSet = "utf8"
 	conf.Language = "us_english"

--- a/tds/packetHeader.go
+++ b/tds/packetHeader.go
@@ -74,7 +74,7 @@ const (
 	TDS_BUFSTAT_SYMENCRYPT PacketHeaderStatus = 0x40
 )
 
-//PacketHeader contains information about the packet-header.
+// PacketHeader contains information about the packet-header.
 type PacketHeader struct {
 	// Message type, e.g. for login or language command
 	MsgType PacketHeaderType


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Some non-code parts still referenced the old repo layout.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
