### PR TITLE
Handle empty numeric cells

### DIFF
--- a/asetypes/decimal.go
+++ b/asetypes/decimal.go
@@ -80,6 +80,7 @@ func NewDecimal(precision, scale int) (*Decimal, error) {
 	dec := &Decimal{
 		Precision: precision,
 		Scale:     scale,
+		i:         new(big.Int),
 	}
 
 	if err := dec.sanity(); err != nil {
@@ -160,10 +161,6 @@ func (dec Decimal) ByteSize() int {
 
 // SetInt64 sets dec.i to i.
 func (dec *Decimal) SetInt64(i int64) {
-	if dec.i == nil {
-		dec.i = &big.Int{}
-	}
-
 	dec.i.SetInt64(i)
 }
 
@@ -177,10 +174,6 @@ func (dec Decimal) Int() *big.Int {
 // SetBytes interprets b as the bytes of a big-endian unsigned integer
 // and sets dec to that values.
 func (dec *Decimal) SetBytes(b []byte) {
-	if dec.i == nil {
-		dec.i = &big.Int{}
-	}
-
 	dec.i.SetBytes(b)
 }
 

--- a/asetypes/goValue.go
+++ b/asetypes/goValue.go
@@ -173,6 +173,10 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 			return nil, fmt.Errorf("error creating decimal: %w", err)
 		}
 
+		if len(bs) == 0 {
+			return dec, nil
+		}
+
 		dec.SetBytes(bs[1:])
 		if bs[0] == 0x1 {
 			dec.Negate()


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

ASE sends no bytes for zeroed numerics/decimals (NUMN).


**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
