### PR TITLE
Fix term parsing flags using flags.Parse

### DIFF
--- a/term/term.go
+++ b/term/term.go
@@ -20,14 +20,12 @@ var (
 
 // Entrypoint controls the execution of the program by starting the
 // interactive command-line or executing the passed query or input-file.
-func Entrypoint(db *sql.DB) error {
-	flag.Parse()
-
-	if len(flag.Args()) == 0 && *fInputFile == "" {
+func Entrypoint(db *sql.DB, args []string) error {
+	if len(args) == 0 && *fInputFile == "" {
 		return Repl(db)
 	}
 
-	query := strings.Join(flag.Args(), " ") + ";"
+	query := strings.Join(args, " ") + ";"
 
 	if *fInputFile != "" {
 		bs, err := ioutil.ReadFile(*fInputFile)


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

As flag handling is handed off to the consumer term.Entrypoint doesn't
need to parse flags itself.


**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
