### PR TITLE
Fix panics from namepool if a name gets released multiple times

### DIFF
--- a/namepool/pool.go
+++ b/namepool/pool.go
@@ -45,6 +45,7 @@ func (pool *pool) Acquire() *Name {
 	id := pool.idPool.Get().(*uint64)
 
 	return &Name{
+		pool: pool,
 		name: fmt.Sprintf(pool.format, *id),
 		id:   id,
 	}
@@ -53,6 +54,11 @@ func (pool *pool) Acquire() *Name {
 // Release returns a name to the name pool. The value name points to
 // will be reset to a default Name.
 func (pool *pool) Release(name *Name) {
+	// Prevent nil IDs in pool if a name gets release multiple times.
+	if name == nil || name.id == nil {
+		return
+	}
+
 	pool.idPool.Put(name.id)
 	*name = Name{}
 }

--- a/namepool/pool_test.go
+++ b/namepool/pool_test.go
@@ -6,6 +6,7 @@
 package namepool
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -49,6 +50,47 @@ func TestNewPool(t *testing.T) {
 	}
 }
 
+func TestPool_AcquireConcurrent(t *testing.T) {
+	pool := Pool("")
+
+	fn := func(start, finished *sync.WaitGroup, t *testing.T) {
+		// Wait for all goroutines to be started by the main goroutine,
+		// then execute the test.
+		start.Wait()
+		defer finished.Done()
+
+		name := pool.Acquire()
+		if name == nil {
+			t.Errorf("pool.Acquire returned nil value")
+			return
+		}
+		defer pool.Release(name)
+
+		if name.name == "" {
+			t.Errorf("name.name is empty")
+		}
+
+		if *name.id == 0 {
+			t.Errorf("name.id is 0")
+		}
+	}
+
+	concurrents := 1000
+
+	start := new(sync.WaitGroup)
+	start.Add(1)
+
+	finished := new(sync.WaitGroup)
+	finished.Add(concurrents)
+
+	for i := 0; i < concurrents; i++ {
+		go fn(start, finished, t)
+	}
+
+	start.Done()
+	finished.Wait()
+}
+
 func TestPool_Release(t *testing.T) {
 	pool := Pool("%d")
 
@@ -64,5 +106,25 @@ func TestPool_Release(t *testing.T) {
 	}
 	if (*name).name != "" {
 		t.Errorf("Released Name has non-empty name")
+	}
+}
+
+func TestPool_ReleaseMultiple(t *testing.T) {
+	pool := Pool("")
+
+	name := pool.Acquire()
+
+	name.Release()
+	if name.id != nil {
+		t.Errorf("Release Name has non-nil ID pointer")
+	}
+
+	// Release a second time to check that no nil pointer gets into the
+	// pool.
+	name.Release()
+
+	secondName := pool.Acquire()
+	if secondName.id == nil {
+		t.Errorf("Received nil ID pointer from pool")
 	}
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fixes two issues:
1. `Name`s weren't getting a reference to the pool they belong to
2. Pool may receive a nil pointer back if a name gets released multiple times

I originally thought the error might occur due to concurrent use of the namepool (although that should be impossible as this uses atomic) and wrote a test for that. I'm leaving it in in case it becomes relevant in the future.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
