### PR TITLE
Fix linter workflow by tidying go.sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+      - run: go mod tidy -v
       - uses: golangci/golangci-lint-action@v2.5.1
         with:
           version: v1.28


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Attempt to fix linter by tidying go.sum before executing linter.

**Related issues**

-

**Tests**

- [x] make lint
- [x] make test
