### PR TITLE
Readd go.sum license header

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Readds the go.sum license header.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test
