### PR TITLE
Handle null INTN and UINTN values

### DIFF
--- a/asetypes/goValue.go
+++ b/asetypes/goValue.go
@@ -54,7 +54,7 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 	case INTN:
 		switch len(bs) {
 		case 0:
-			return 0, nil
+			return nil, nil
 		case 1:
 			return INT1.GoValue(endian, bs)
 		case 2:
@@ -81,7 +81,7 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 	case UINTN:
 		switch len(bs) {
 		case 0:
-			return 0, nil
+			return nil, nil
 		case 1:
 			return INT1.GoValue(endian, bs)
 		case 2:


### PR DESCRIPTION
**Description**

This pull request returns null `INTN` and `UINTN` as `nil` values to be handled appropriately by `database/sql.Driver`. As mentioned in #203, `NULL` is returned as a zero value instead of `NULL` so `sql.NullInt64` cannot determine the difference between a `0` and `NULL`.

**Related issues**

https://github.com/SAP/go-ase/issues/203

**Tests**

I had some issues getting integration tests running but I was able to confirm this works using an internal test harness. 

- [x] make lint
- [x] make test
