### PR TITLE
Seed rand with current unix time

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // DBTestFunc is the interface for tests accepting a pre-connected
@@ -34,6 +35,11 @@ func TestForEachDB(testName string, t *testing.T, testFn DBTestFunc) {
 			},
 		)
 	}
+}
+
+func init() {
+	// Set seed for RandomNumber
+	rand.Seed(time.Now().Unix())
 }
 
 // RandomNumber returns an unsecure random number as a string.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Seed rand with current unix time for actually random `RandomNumber()` output.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test
