### PR TITLE
Rewrite integration setup/teardown to wait on current ASE processes

### DIFF
--- a/integration/setup_teardown.go
+++ b/integration/setup_teardown.go
@@ -139,7 +139,7 @@ func SetupDB(ctx context.Context, info interface{}, dbname string) error {
 	}
 
 	if err := waitForDBInSysdatabases(ctx, db, dbname); err != nil {
-		return fmt.Errorf("integration: error waiting for database %q to available in master..sysdatabases: %w", dbname, err)
+		return fmt.Errorf("integration: error waiting for database %q to be available in master..sysdatabases: %w", dbname, err)
 	}
 
 	if _, err := conn.ExecContext(ctx, "use "+dbname); err != nil {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fixes the timing issues when creating databases in ASE, leading to spurious failures.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test
